### PR TITLE
Check error before defer response body close

### DIFF
--- a/sms.go
+++ b/sms.go
@@ -174,11 +174,11 @@ func (c *SMS) Send(msg *SMSMessage) (*MessageResponse, error) {
 	r.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 
 	resp, err := client.Do(r)
-	defer resp.Body.Close()
 
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	body, _ := ioutil.ReadAll(resp.Body)
 


### PR DESCRIPTION
Hi,
When an error occurs during http post, the body is nil and trying to close the body would cause the program to panic. Therefore, it would be better to check error right after http post.

thanks

km
