### PR TITLE
Update account.go

### DIFF
--- a/account.go
+++ b/account.go
@@ -22,22 +22,35 @@ func (nexmo *Account) GetBalance() (float64, error) {
 	var accBalance *AccountBalance
 
 	client := &http.Client{}
-	r, _ := http.NewRequest("GET", apiRoot+"/account/get-balance/"+
+	r, reqErr := http.NewRequest("GET", apiRoot+"/account/get-balance/"+
 		nexmo.client.apiKey+"/"+nexmo.client.apiSecret, nil)
+
+	if reqErr != nil {
+		return 0.0, reqErr
+	}
+
 	r.Header.Add("Accept", "application/json")
 
 	resp, err := client.Do(r)
-	defer resp.Body.Close()
-
 	if err != nil {
 		return 0.0, err
 	}
 
-	body, _ := ioutil.ReadAll(resp.Body)
+	defer func() {
+		if resp != nil && resp.Body != nil {
+			resp.Body.Close()
+		}
+	}()
+
+	body, readErr := ioutil.ReadAll(resp.Body)
+	if readErr != nil {
+		return 0.0, readErr
+	}
 
 	err = json.Unmarshal(body, &accBalance)
 	if err != nil {
 		return 0.0, err
 	}
+
 	return accBalance.Value, nil
 }


### PR DESCRIPTION
This change adds a few more error checking, and also attempts to close the response body only if not nil. 
There were a few instances, especially an awkward circumstance, where the development laptop went into sleep mode then, then, when it went back to normal operation, the dns resolver was not operational for a few seconds.
This triggered a panic because the error (unable to resolve the nexmo api hostname) had not been previously captured.