### PR TITLE
Add more optional verification parameters

### DIFF
--- a/verify.go
+++ b/verify.go
@@ -33,11 +33,14 @@ type VerifyMessageRequest struct {
 	apiKey    string
 	apiSecret string
 
-	Number   string `json:"number"`
-	Brand    string `json:"brand"`
-	SenderID string `json:"sender_id,omitempty"`
-	Country  string `json:"country,omitempty"`
-	Language string `json:"lg,omitempty"`
+	Number        string `json:"number"`
+	Brand         string `json:"brand"`
+	SenderID      string `json:"sender_id,omitempty"`
+	Country       string `json:"country,omitempty"`
+	Language      string `json:"lg,omitempty"`
+	CodeLength    int    `json:"code_length,omitempty"`
+	PINExpiry     int    `json:"pin_expiry,omitempty"`
+	NextEventWait int    `json:"next_event_wait,omitempty"`
 }
 
 // VerifyMessageResponse is the struct for the response from the verify


### PR DESCRIPTION
This adds the following verification parameters to the verification request to Nexmo:

- Code length
- PIN expiry
- Next event wait

The parameters are documented here https://docs.nexmo.com/verify/api-reference/api-reference#vrequest in the Nexmo API documentation.

I did not see any tests for similar options, so I have omitted that in this PR as well. Please let me know if I need to do anything else related to that.