### PR TITLE
Adding callback attribute.

### DIFF
--- a/sms.go
+++ b/sms.go
@@ -86,6 +86,7 @@ type SMSMessage struct {
 	VCal                 string       `json:"vcal,omitempty"`              // Optional.
 	TTL                  int          `json:"ttl,omitempty"`               // Optional.
 	Class                MessageClass `json:"message-class,omitempty"`     // Optional.
+	Callback             string       `json:"callback,omitempty"`          // Optional.
 	Body                 []byte       `json:"body,omitempty"`              // Required for Binary message.
 	UDH                  []byte       `json:"udh,omitempty"`               // Required for Binary message.
 


### PR DESCRIPTION
According to the documentation, when you send a message there is an option to set the callback url for the delivery receipt.

![image](https://user-images.githubusercontent.com/2598012/35731498-effe69a0-07fc-11e8-825f-12c2f274947e.png)
