### PR TITLE
Extract parsing of response data to their own functions

### DIFF
--- a/account_test.go
+++ b/account_test.go
@@ -5,6 +5,8 @@ import (
 )
 
 func TestGetAccountBalance(t *testing.T) {
+	InitEnv()
+
 	client, err := NewClient(testAPIKey, testAPISecret)
 	if err != nil {
 		t.Error("Failed to create Client with error:", err)

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/wheniwork/gonexmo
+module github.com/wheniwork/gonexmo/v2
 
 go 1.14

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/wheniwork/gonexmo
+
+go 1.14

--- a/gonexmo_test.go
+++ b/gonexmo_test.go
@@ -13,7 +13,7 @@ var (
 	testFrom        string
 )
 
-func init() {
+func InitEnv() {
 	testAPIKey = os.Getenv("NEXMO_KEY")
 	if testAPIKey == "" {
 		fmt.Println("No API key specified. Please set NEXMO_KEY")
@@ -38,6 +38,7 @@ func init() {
 }
 
 func TestNexmoCreation(t *testing.T) {
+	InitEnv()
 	_, err := NewClient(testAPIKey, testAPISecret)
 	if err != nil {
 		t.Error("failed to create Client with error:", err)

--- a/server.go
+++ b/server.go
@@ -1,6 +1,7 @@
 package nexmo
 
 import (
+	"fmt"
 	"net"
 	"net/http"
 	"net/url"
@@ -103,9 +104,56 @@ type DeliveryReceipt struct {
 	ClientReference string    `json:"client-ref"`
 }
 
+func ParseDeliveryReceipt(req *http.Request) (*DeliveryReceipt, error) {
+	err := req.ParseForm()
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse form data: %v", err)
+	}
+
+	// Decode the form data
+	m := new(DeliveryReceipt)
+
+	m.To = req.FormValue("to")
+	m.NetworkCode = req.FormValue("network-code")
+	m.MessageID = req.FormValue("messageId")
+	m.MSISDN = req.FormValue("msisdn")
+	m.Status = req.FormValue("status")
+	m.ErrorCode = req.FormValue("err-code")
+	m.Price = req.FormValue("price")
+	m.ClientReference = req.FormValue("client-ref")
+
+	t, err := url.QueryUnescape(req.FormValue("scts"))
+	if err != nil {
+		return nil, fmt.Errorf("failed to unescape field 'scts': %v", err)
+	}
+
+	// Convert the timestamp to a time.Time.
+	timestamp, err := time.Parse("0601021504", t)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse timestamp for field 'scts': %v", err)
+	}
+
+	m.SCTS = timestamp
+
+	t, err = url.QueryUnescape(req.FormValue("message-timestamp"))
+	if err != nil {
+		return nil, fmt.Errorf("failed to unescape field 'message-timestamp': %v", err)
+	}
+
+	// Convert the timestamp to a time.Time.
+	timestamp, err = time.Parse("2006-01-02 15:04:05", t)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse timestamp for field 'message-timestamp': %v", err)
+	}
+
+	m.Timestamp = timestamp
+
+	return m, nil
+}
+
 // NewDeliveryHandler creates a new http.HandlerFunc that can be used to listen
 // for delivery receipts from the Nexmo server. Any receipts received will be
-// decoded nad passed to the out chan.
+// decoded and passed to the out chan.
 func NewDeliveryHandler(out chan *DeliveryReceipt, verifyIPs bool) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
 		if verifyIPs {
@@ -117,7 +165,6 @@ func NewDeliveryHandler(out chan *DeliveryReceipt, verifyIPs bool) http.HandlerF
 			}
 		}
 
-		var err error
 		// Check if the query is empty. If it is, it's just Nexmo
 		// making sure our service is up, so we don't want to return
 		// an error.
@@ -125,53 +172,97 @@ func NewDeliveryHandler(out chan *DeliveryReceipt, verifyIPs bool) http.HandlerF
 			return
 		}
 
-		req.ParseForm()
-		// Decode the form data
-		m := new(DeliveryReceipt)
-
-		m.To = req.FormValue("to")
-		m.NetworkCode = req.FormValue("network-code")
-		m.MessageID = req.FormValue("messageId")
-		m.MSISDN = req.FormValue("msisdn")
-		m.Status = req.FormValue("status")
-		m.ErrorCode = req.FormValue("err-code")
-		m.Price = req.FormValue("price")
-		m.ClientReference = req.FormValue("client-ref")
-
-		t, err := url.QueryUnescape(req.FormValue("scts"))
+		receipt, err := ParseDeliveryReceipt(req)
 		if err != nil {
 			http.Error(w, "", http.StatusInternalServerError)
 			return
 		}
-
-		// Convert the timestamp to a time.Time.
-		timestamp, err := time.Parse("0601021504", t)
-		if err != nil {
-			http.Error(w, "", http.StatusInternalServerError)
-			return
-		}
-
-		m.SCTS = timestamp
-
-		t, err = url.QueryUnescape(req.FormValue("message-timestamp"))
-		if err != nil {
-			http.Error(w, "", http.StatusInternalServerError)
-			return
-		}
-
-		// Convert the timestamp to a time.Time.
-		timestamp, err = time.Parse("2006-01-02 15:04:05", t)
-		if err != nil {
-			http.Error(w, "", http.StatusInternalServerError)
-			return
-		}
-
-		m.Timestamp = timestamp
 
 		// Pass it out on the chan
-		out <- m
+		out <- receipt
+	}
+}
+
+func ParseReceivedMessage(req *http.Request) (*ReceivedMessage, error) {
+	err := req.ParseForm()
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse form data: %v", err)
 	}
 
+	// Decode the form data
+	m := new(ReceivedMessage)
+	switch t := req.FormValue("type"); t {
+	case "text":
+		m.Text, err = url.QueryUnescape(req.FormValue("text"))
+		if err != nil {
+			return nil, fmt.Errorf("failed to unescape field 'text': %v", err)
+		}
+		m.Type = TextMessage
+
+	case "unicode":
+		m.Text, err = url.QueryUnescape(req.FormValue("text"))
+		if err != nil {
+			return nil, fmt.Errorf("failed to unescape field 'text': %v", err)
+		}
+		m.Type = UnicodeMessage
+
+	case "binary":
+		// TODO: I have no idea if this data stuff works, as I'm unable to
+		// send data SMS messages.
+		data, err := url.QueryUnescape(req.FormValue("data"))
+		if err != nil {
+			return nil, fmt.Errorf("failed to unescape field 'data': %v", err)
+		}
+		m.Data = []byte(data)
+
+		udh, err := url.QueryUnescape(req.FormValue("udh"))
+		if err != nil {
+			return nil, fmt.Errorf("failed to unescape field 'udh': %v", err)
+		}
+		m.UDH = []byte(udh)
+		m.Type = BinaryMessage
+
+	default:
+		//error
+		return nil, fmt.Errorf("unrecognized message type %s", t)
+	}
+
+	m.To = req.FormValue("to")
+	m.MSISDN = req.FormValue("msisdn")
+	m.NetworkCode = req.FormValue("network-code")
+	m.ID = req.FormValue("messageId")
+
+	m.Keyword = req.FormValue("keyword")
+	t, err := url.QueryUnescape(req.FormValue("message-timestamp"))
+	if err != nil {
+		return nil, fmt.Errorf("failed to unescape field 'message-timestamp': %v", err)
+	}
+
+	// Convert the timestamp to a time.Time.
+	timestamp, err := time.Parse("2006-01-02 15:04:05", t)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse timestamp for field 'message-timestamp': %v", err)
+	}
+
+	m.Timestamp = timestamp
+
+	// TODO: I don't know if this works as I've been unable to send an SMS
+	// message longer than 160 characters that doesn't get concatenated
+	// automatically.
+	if req.FormValue("concat") == "true" {
+		m.Concatenated = true
+		m.Concat.Reference = req.FormValue("concat-ref")
+		m.Concat.Total, err = strconv.Atoi(req.FormValue("concat-total"))
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert field 'concat-total' to int: %v", err)
+		}
+		m.Concat.Part, err = strconv.Atoi(req.FormValue("concat-part"))
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert field 'concat-part' to int: %v", err)
+		}
+	}
+
+	return m, nil
 }
 
 // NewMessageHandler creates a new http.HandlerFunc that can be used to listen
@@ -188,8 +279,6 @@ func NewMessageHandler(out chan *ReceivedMessage, verifyIPs bool) http.HandlerFu
 			}
 		}
 
-		var err error
-
 		// Check if the query is empty. If it is, it's just Nexmo
 		// making sure our service is up, so we don't want to return
 		// an error.
@@ -197,90 +286,13 @@ func NewMessageHandler(out chan *ReceivedMessage, verifyIPs bool) http.HandlerFu
 			return
 		}
 
-		req.ParseForm()
-		// Decode the form data
-		m := new(ReceivedMessage)
-		switch req.FormValue("type") {
-		case "text":
-			m.Text, err = url.QueryUnescape(req.FormValue("text"))
-			if err != nil {
-				http.Error(w, "", http.StatusInternalServerError)
-				return
-			}
-			m.Type = TextMessage
-		case "unicode":
-			m.Text, err = url.QueryUnescape(req.FormValue("text"))
-			if err != nil {
-				http.Error(w, "", http.StatusInternalServerError)
-				return
-			}
-			m.Type = UnicodeMessage
-
-			// TODO: I have no idea if this data stuff works, as I'm unable to
-			// send data SMS messages.
-		case "binary":
-			data, err := url.QueryUnescape(req.FormValue("data"))
-			if err != nil {
-				http.Error(w, "", http.StatusInternalServerError)
-				return
-			}
-			m.Data = []byte(data)
-
-			udh, err := url.QueryUnescape(req.FormValue("udh"))
-			if err != nil {
-				http.Error(w, "", http.StatusInternalServerError)
-				return
-			}
-			m.UDH = []byte(udh)
-			m.Type = BinaryMessage
-
-		default:
-			//error
-			http.Error(w, "", http.StatusInternalServerError)
-			return
-		}
-
-		m.To = req.FormValue("to")
-		m.MSISDN = req.FormValue("msisdn")
-		m.NetworkCode = req.FormValue("network-code")
-		m.ID = req.FormValue("messageId")
-
-		m.Keyword = req.FormValue("keyword")
-		t, err := url.QueryUnescape(req.FormValue("message-timestamp"))
+		message, err := ParseReceivedMessage(req)
 		if err != nil {
 			http.Error(w, "", http.StatusInternalServerError)
 			return
-		}
-
-		// Convert the timestamp to a time.Time.
-		timestamp, err := time.Parse("2006-01-02 15:04:05", t)
-		if err != nil {
-			http.Error(w, "", http.StatusInternalServerError)
-			return
-		}
-
-		m.Timestamp = timestamp
-
-		// TODO: I don't know if this works as I've been unable to send an SMS
-		// message longer than 160 characters that doesn't get concatenated
-		// automatically.
-		if req.FormValue("concat") == "true" {
-			m.Concatenated = true
-			m.Concat.Reference = req.FormValue("concat-ref")
-			m.Concat.Total, err = strconv.Atoi(req.FormValue("concat-total"))
-			if err != nil {
-				http.Error(w, "", http.StatusInternalServerError)
-				return
-			}
-			m.Concat.Part, err = strconv.Atoi(req.FormValue("concat-part"))
-			if err != nil {
-				http.Error(w, "", http.StatusInternalServerError)
-				return
-			}
 		}
 
 		// Pass it out on the chan
-		out <- m
+		out <- message
 	}
-
 }

--- a/server.go
+++ b/server.go
@@ -104,6 +104,8 @@ type DeliveryReceipt struct {
 	ClientReference string    `json:"client-ref"`
 }
 
+// ParseReceivedMessage unmarshals and processes the form data in a Nexmo request
+// and returns a DeliveryReceipt struct.
 func ParseDeliveryReceipt(req *http.Request) (*DeliveryReceipt, error) {
 	err := req.ParseForm()
 	if err != nil {
@@ -183,6 +185,8 @@ func NewDeliveryHandler(out chan *DeliveryReceipt, verifyIPs bool) http.HandlerF
 	}
 }
 
+// ParseReceivedMessage unmarshals and processes the form data in a Nexmo request
+// and returns a ReceivedMessage struct.
 func ParseReceivedMessage(req *http.Request) (*ReceivedMessage, error) {
 	err := req.ParseForm()
 	if err != nil {

--- a/server.go
+++ b/server.go
@@ -124,35 +124,41 @@ func ParseDeliveryReceipt(req *http.Request) (*DeliveryReceipt, error) {
 	m.Price = req.FormValue("price")
 	m.ClientReference = req.FormValue("client-ref")
 
-	t, err := url.QueryUnescape(req.FormValue("scts"))
-	if err != nil {
-		return nil, fmt.Errorf("failed to unescape field 'scts': %v", err)
-	}
-
-	// Convert the timestamp to a time.Time.
-	var timestamp time.Time
-	if t != "" {
-		var err error
-		timestamp, err = time.Parse("0601021504", t)
+	{
+		t, err := url.QueryUnescape(req.FormValue("scts"))
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse timestamp for field 'scts': %v", err)
+			return nil, fmt.Errorf("failed to unescape field 'scts': %v", err)
 		}
+
+		// Convert the timestamp to a time.Time.
+		var timestamp time.Time
+		if t != "" {
+			timestamp, err = time.Parse("0601021504", t)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse timestamp for field 'scts': %v", err)
+			}
+		}
+
+		m.SCTS = timestamp
 	}
 
-	m.SCTS = timestamp
+	{
+		t, err := url.QueryUnescape(req.FormValue("message-timestamp"))
+		if err != nil {
+			return nil, fmt.Errorf("failed to unescape field 'message-timestamp': %v", err)
+		}
 
-	t, err = url.QueryUnescape(req.FormValue("message-timestamp"))
-	if err != nil {
-		return nil, fmt.Errorf("failed to unescape field 'message-timestamp': %v", err)
+		// Convert the timestamp to a time.Time.
+		var timestamp time.Time
+		if t != "" {
+			timestamp, err = time.Parse("2006-01-02 15:04:05", t)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse timestamp for field 'message-timestamp': %v", err)
+			}
+		}
+
+		m.Timestamp = timestamp
 	}
-
-	// Convert the timestamp to a time.Time.
-	timestamp, err = time.Parse("2006-01-02 15:04:05", t)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse timestamp for field 'message-timestamp': %v", err)
-	}
-
-	m.Timestamp = timestamp
 
 	return m, nil
 }

--- a/server.go
+++ b/server.go
@@ -130,9 +130,13 @@ func ParseDeliveryReceipt(req *http.Request) (*DeliveryReceipt, error) {
 	}
 
 	// Convert the timestamp to a time.Time.
-	timestamp, err := time.Parse("0601021504", t)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse timestamp for field 'scts': %v", err)
+	var timestamp time.Time
+	if t != "" {
+		var err error
+		timestamp, err = time.Parse("0601021504", t)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse timestamp for field 'scts': %v", err)
+		}
 	}
 
 	m.SCTS = timestamp

--- a/server_test.go
+++ b/server_test.go
@@ -1,0 +1,40 @@
+package nexmo
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseSCTS(t *testing.T) {
+	if result, err := parseSCTS(""); err != nil {
+		t.Errorf("Failed to parse empty string: %v", err)
+	} else if !result.IsZero() {
+		t.Errorf("Did not get a zero time from an empty string: %v", result)
+	}
+}
+
+func TestParseMessageTimestamp(t *testing.T) {
+	if result, err := parseMessageTimestamp(""); err != nil {
+		t.Errorf("Failed to parse empty string: %v", err)
+	} else if !result.IsZero() {
+		t.Errorf("Did not get a zero time from an empty string: %v", result)
+	}
+
+	if result, err := parseMessageTimestamp("2022-05-05 14:35:48 0000"); err != nil {
+		t.Errorf("Failed to parse empty string: %v", err)
+	} else if !result.Equal(time.Date(2022, 5, 5, 14, 35, 48, 0, time.UTC)) {
+		t.Errorf("Wrong time: %v", result)
+	}
+
+	if result, err := parseMessageTimestamp("2022-05-05 14:35:48  0000"); err != nil {
+		t.Errorf("Failed to parse empty string: %v", err)
+	} else if !result.Equal(time.Date(2022, 5, 5, 14, 35, 48, 0, time.UTC)) {
+		t.Errorf("Wrong time: %v", result)
+	}
+
+	if result, err := parseMessageTimestamp("2022-05-05 16:05:13 +0000"); err != nil {
+		t.Errorf("Failed to parse empty string: %v", err)
+	} else if !result.Equal(time.Date(2022, 5, 5, 16, 5, 13, 0, time.UTC)) {
+		t.Errorf("Wrong time: %v", result)
+	}
+}

--- a/sms.go
+++ b/sms.go
@@ -2,10 +2,13 @@ package nexmo
 
 import (
 	"bytes"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/http/httptrace"
 )
 
 // SMS represents the SMS API functions for sending text messages.
@@ -24,10 +27,10 @@ const (
 )
 
 // MessageClass will be one of the following:
-//	- Flash
-//	- Standard
-//	- SIMData
-//	- Forward
+//   - Flash
+//   - Standard
+//   - SIMData
+//   - Forward
 type MessageClass int
 
 // SMS message classes.
@@ -179,7 +182,19 @@ type MessageResponse struct {
 
 type InvalidResponseError struct {
 	Message string
+	Err     error
 	Body    []byte
+}
+
+type SendConnectionError struct {
+	Message string
+	Err     error
+	Body    []byte
+	Debug   []string
+}
+
+func (e SendConnectionError) Error() string {
+	return e.Message
 }
 
 func (e InvalidResponseError) Error() string {
@@ -224,6 +239,7 @@ func (c *SMS) Send(msg *SMSMessage) (*MessageResponse, error) {
 	}
 
 	var r *http.Request
+
 	buf, err := json.Marshal(msg)
 	if err != nil {
 		return nil, errors.New("invalid message struct - unable to convert to JSON")
@@ -234,18 +250,36 @@ func (c *SMS) Send(msg *SMSMessage) (*MessageResponse, error) {
 	r.Header.Add("Accept", "application/json")
 	r.Header.Add("Content-Type", "application/json")
 
+	debug, trace := getRequestTrace()
+	r = r.WithContext(httptrace.WithClientTrace(r.Context(), trace))
+
 	resp, err := c.client.HTTPClient.Do(r)
 
 	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
+		sendErr := SendConnectionError{
+			Message: "nexmo http send failed",
+			Err:     err,
+			Debug:   *debug,
+		}
 
+		if resp != nil && resp.Body != nil {
+			defer resp.Body.Close()
+			body, bodyErr := ioutil.ReadAll(resp.Body)
+			if bodyErr != nil {
+				sendErr.Body = body
+			}
+		}
+
+		return nil, sendErr
+	}
+
+	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return nil, InvalidResponseError{
 			Message: "failed to read response from Nexmo",
 			Body:    body,
+			Err:     err,
 		}
 	}
 
@@ -254,7 +288,70 @@ func (c *SMS) Send(msg *SMSMessage) (*MessageResponse, error) {
 		return nil, InvalidResponseError{
 			Message: "failed to unmarshal response from Nexmo",
 			Body:    body,
+			Err:     err,
 		}
 	}
+
 	return messageResponse, nil
+}
+
+func getRequestTrace() (*[]string, *httptrace.ClientTrace) {
+
+	debugTrace := &[]string{}
+
+	return debugTrace, &httptrace.ClientTrace{
+		GetConn: func(hostPort string) {
+			*debugTrace = append(*debugTrace, fmt.Sprintf("Initiating connecting to %s", hostPort))
+		},
+		GotConn: func(connInfo httptrace.GotConnInfo) {
+			if connInfo.Reused {
+				*debugTrace = append(*debugTrace, "Re-using existing connection")
+			} else {
+				*debugTrace = append(*debugTrace, "New connection successfully established")
+			}
+		},
+		DNSStart: func(dnsInfo httptrace.DNSStartInfo) {
+			*debugTrace = append(*debugTrace, fmt.Sprintf("Resolving DNS for %s", dnsInfo.Host))
+		},
+		DNSDone: func(dnsInfo httptrace.DNSDoneInfo) {
+			if dnsInfo.Err != nil {
+				*debugTrace = append(*debugTrace, fmt.Sprintf("Error resolving DNS (%s)", dnsInfo.Err.Error()))
+			} else {
+				*debugTrace = append(*debugTrace, "DNS resolved successfully")
+			}
+		},
+		ConnectStart: func(network string, addr string) {
+			*debugTrace = append(*debugTrace, fmt.Sprintf("Initiating connecting to %s %s", network, addr))
+		},
+		ConnectDone: func(network string, addr string, err error) {
+			if err != nil {
+				*debugTrace = append(*debugTrace, fmt.Sprintf("Error connecting to %s %s (%s)", network, addr, err.Error()))
+			} else {
+				*debugTrace = append(*debugTrace, fmt.Sprintf("Connection complete to %s %s", network, addr))
+			}
+		},
+		GotFirstResponseByte: func() {
+			*debugTrace = append(*debugTrace, "Read first byte of response headers")
+		},
+		TLSHandshakeStart: func() {
+			*debugTrace = append(*debugTrace, "TLS handshake started")
+		},
+		TLSHandshakeDone: func(state tls.ConnectionState, err error) {
+			if err != nil {
+				*debugTrace = append(*debugTrace, fmt.Sprintf("TLS handshake error (%s)", err.Error()))
+			} else {
+				*debugTrace = append(*debugTrace, "TLS handshake complete")
+			}
+		},
+		WroteHeaders: func() {
+			*debugTrace = append(*debugTrace, "Request headers successfully written")
+		},
+		WroteRequest: func(requestInfo httptrace.WroteRequestInfo) {
+			if requestInfo.Err != nil {
+				*debugTrace = append(*debugTrace, fmt.Sprintf("Error while writing http request (%s)", requestInfo.Err.Error()))
+			} else {
+				*debugTrace = append(*debugTrace, "Full request successfully written")
+			}
+		},
+	}
 }

--- a/sms_test.go
+++ b/sms_test.go
@@ -1,3 +1,4 @@
+//go:build messages
 // +build messages
 
 // Tests in this file will only be run if the build tag messages is set:
@@ -17,6 +18,8 @@ import (
 // TODO(inhies): Only create a Client once in an init() function.
 
 func TestSendTextMessage(t *testing.T) {
+	InitEnv()
+
 	// TODO(inhies): Create an internal rate limiting system and do away with
 	// this hacky 1 second delay.
 	time.Sleep(1 * time.Second) // Sleep 1 second due to API limitation
@@ -46,6 +49,8 @@ func TestSendTextMessage(t *testing.T) {
 }
 
 func TestFlashMessage(t *testing.T) {
+	InitEnv()
+
 	time.Sleep(1 * time.Second) // Sleep 1 second due to API limitation
 	if TEST_PHONE_NUMBER == "" {
 		t.Fatal("No test phone number specified. Please set NEXMO_NUM")

--- a/ussd_test.go
+++ b/ussd_test.go
@@ -1,3 +1,4 @@
+//go:build messages
 // +build messages
 
 // Tests in this file will only be run if the build tag messages is set:
@@ -13,6 +14,8 @@ import (
 )
 
 func TestUssdPushMessage(t *testing.T) {
+	InitEnv()
+
 	time.Sleep(1 * time.Second) // Sleep 1 second due to API limitation
 	if TEST_PHONE_NUMBER == "" {
 		t.Fatal("No test phone number specified. Please set NEXMO_NUM")
@@ -37,6 +40,8 @@ func TestUssdPushMessage(t *testing.T) {
 }
 
 func TestUssdPromptMessage(t *testing.T) {
+	InitEnv()
+
 	time.Sleep(1 * time.Second) // Sleep 1 second due to API limitation
 	if TEST_PHONE_NUMBER == "" {
 		t.Fatal("No test phone number specified. Please set NEXMO_NUM")

--- a/verify_test.go
+++ b/verify_test.go
@@ -6,6 +6,8 @@ import (
 )
 
 func testSend(t *testing.T) *VerifyMessageResponse {
+	InitEnv()
+
 	time.Sleep(1 * time.Second) // Sleep 1 second due to API limitation
 	if testPhoneNumber == "" {
 		t.Fatal("no test phone number specified. Please set NEXMO_NUM")


### PR DESCRIPTION
We found that we wanted to use parts of this library without being forced to use the provided delivery handler. This PR simply extracts the request-decoding parts of the process to their own functions. This should be completely backwards-compatible.

cc @Dave-Dohmeier